### PR TITLE
Fix crash on '\' to adjust auto-pickup.

### DIFF
--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -1030,6 +1030,9 @@ static bool _is_affordable(const item_def &item)
 //
 bool item_ident(const item_def &item, iflags_t flags)
 {
+    if (item.base_type == OBJ_BOOKS && item.sub_type >= NUM_BOOKS)
+        return false;
+
     // return (item.flags & flags) == flags;
     return true;
 }


### PR DESCRIPTION
Some of the menu logic gets confused when it tries to handle an "identified" out of bounds book. I had the same problem in Quick Crawl.